### PR TITLE
Add mitmproxy system user for UID-based iptables exclusion

### DIFF
--- a/template.py
+++ b/template.py
@@ -32,6 +32,14 @@ template = (
     .run_cmd(
         "pip install claude-code-sdk claude-agent-sdk==0.1.6 anyio boto3 e2b-code-interpreter GitPython datadog-api-client"
     )
+    # Create dedicated user for MITM proxy adapter.
+    # iptables uses --uid-owner to bypass proxy adapter's own traffic, preventing
+    # routing loops without relying on destination IP (which fails when hosts share
+    # Cloudflare Anycast IPs).
+    .run_cmd("useradd -r -M -s /usr/sbin/nologin mitmproxy")
+    .run_cmd(
+        'echo "mitmproxy ALL=(ALL) NOPASSWD: /usr/bin/cp, /usr/sbin/update-ca-certificates" > /etc/sudoers.d/mitmproxy && chmod 440 /etc/sudoers.d/mitmproxy'
+    )
     # 切换到普通用户
     .set_user("user")
     .set_workdir("/home/user")


### PR DESCRIPTION
## Summary

- Creates a dedicated `mitmproxy` system user in the E2B template
- Configures sudoers for CA cert installation (`cp` + `update-ca-certificates`)

## Context

The transparent proxy currently excludes upstream hosts (sandbox-proxy.moxt.ai, web-api.moxt.ai) by destination IP to prevent routing loops. However, these hosts share the same Cloudflare Anycast IPs as admin.moxt.ai, so excluding one inadvertently bypasses all `*.moxt.ai` subdomains.

With a dedicated user, `transparent-proxy.ts` (in paramoxt) can spawn the proxy adapter as `mitmproxy` and use `iptables --uid-owner` to bypass only the proxy adapter's own traffic — independent of destination IP.

## Depends on

paramoxt PR (to be created) that modifies `transparent-proxy.ts` to:
1. Spawn proxy adapter with `sudo -u mitmproxy`
2. Add `--uid-owner` iptables rule
3. Remove IP-based exclusion for shared Cloudflare hosts


Made with [Cursor](https://cursor.com)